### PR TITLE
support ipv6

### DIFF
--- a/frontend/src/routes/cluster/cluster.utils.ts
+++ b/frontend/src/routes/cluster/cluster.utils.ts
@@ -17,6 +17,6 @@
 
 export function transformHostToIp(host: string) {
     if (!host.includes(':')) return host;
-    const sliceIndex = host.indexOf(':');
+    const sliceIndex = host.lastIndexOf(':');
     return host.slice(0, sliceIndex);
 }

--- a/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/ResourceNodeAndAgentManager.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/ResourceNodeAndAgentManager.java
@@ -487,6 +487,9 @@ public class ResourceNodeAndAgentManager {
         if (host == null || host.isEmpty()) {
             try {
                 host = InetAddress.getLocalHost().getHostAddress();
+                if (host.split(":").length > 2) {
+                    host = '[' + host + ']';
+                }
             } catch (UnknownHostException e) {
                 throw new ServerException("get server ip fail");
             }

--- a/manager/dm-server/src/main/java/org/apache/doris/stack/shell/SCP.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/shell/SCP.java
@@ -33,7 +33,11 @@ public class SCP extends BaseCommand {
         this.user = user;
         this.sshPort = sshPort;
         this.sshKeyFile = sshKeyFile;
-        this.host = host;
+        if (host != null && host.split(":").length > 2) {
+            this.host = '[' + host + ']';
+        } else {
+            this.host = host;
+        }
         this.localPath = localPath;
         this.remotePath = remotePath;
     }

--- a/manager/resource-common/src/main/java/org/apache/doris/stack/entity/ClusterInfoEntity.java
+++ b/manager/resource-common/src/main/java/org/apache/doris/stack/entity/ClusterInfoEntity.java
@@ -63,6 +63,17 @@ public class ClusterInfoEntity {
 
     private String address;
 
+    public String getAddress() {
+        if (address != null && address.split(":").length > 2) {
+            return '[' + address + ']';
+        }
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
     private int httpPort;
 
     private int queryPort;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. In ipv6 enviromenet the packages which are about to be installed  can not be distributed to the agent when the server does the scp operation. The same problen happens when server does the ssh operation
2. when check the current value of configuration , the ip information only show part of the ipv6 address because of using the "indexof(':') "  funtion,  and there are many ':' in ipv6 address

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
